### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,8 +7,7 @@ Vagrant.configure("2") do |config|
     vb.customize ["modifyvm", :id, "--memory", "1024"]
   end
 
-  config.vm.box = "precise64"
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"  
+  config.vm.box = "hashicorp/precise64"
   config.vm.network "private_network", ip: "192.168.66.6"  
   config.vm.hostname = "widgetbox-php53"
   config.vm.provision "shell", path: "provision.sh"


### PR DESCRIPTION
'vagrant up' spits out: "Failed to connect to hashicorp-files.hashicorp.com port 443: Connection timed out"
This fixes it as described here: https://github.com/hashicorp/vagrant/issues/9897#issuecomment-394945635